### PR TITLE
Update README.md >> sudo permissions error on cloud instance

### DIFF
--- a/jenkins/Install/README.md
+++ b/jenkins/Install/README.md
@@ -10,8 +10,8 @@ sudo apt-get install -y fontconfig openjdk-17-jre openjdk-17-jdk
 cd /tmp ; sudo wget https://dlcdn.apache.org/maven/maven-3/3.9.6/binaries/apache-maven-3.9.6-bin.tar.gz
 cd /tmp ; sudo tar -xzf apache-maven-3.9.6-bin.tar.gz -C  /opt/
 mv /opt/apache-maven-3.9.6 /opt/maven
-sudo echo "MAVEN_HOME=\"/opt/maven\"" >> /etc/profile
-sudo echo "PATH=\$MAVEN_HOME/bin:\$PATH" >> /etc/profile
+sudo sh -c 'echo "MAVEN_HOME=\"/opt/maven\"" >> /etc/profile'
+sudo sh -c 'echo "PATH=\$MAVEN_HOME/bin:\$PATH" >> /etc/profile'
 source /etc/profile
 ````
 ### Install Jenkins


### PR DESCRIPTION
By replacing this command with the previous one, we can mitigate the error of permission denied while executing on a cloud whose root password is unknown. 